### PR TITLE
Topiclist - make grep more restricted

### DIFF
--- a/libraries/kafka_topic.rb
+++ b/libraries/kafka_topic.rb
@@ -55,7 +55,7 @@ module KafkaClusterCookbook
           execute new_resource.command('create') do
             guard_interpreter :default
             environment new_resource.environment
-            not_if new_resource.exists_command, :environment => new_resource.environment
+            not_if new_resource.exists_command, environment: new_resource.environment
           end
         end
       end
@@ -65,7 +65,7 @@ module KafkaClusterCookbook
           execute new_resource.command('alter') do
             guard_interpreter :default
             environment new_resource.environment
-            only_if new_resource.exists_command, :environment => new_resource.environment
+            only_if new_resource.exists_command, environment: new_resource.environment
           end
         end
       end
@@ -75,7 +75,7 @@ module KafkaClusterCookbook
           execute new_resource.command('delete') do
             guard_interpreter :default
             environment new_resource.environment
-            only_if new_resource.exists_command, :environment => new_resource.environment
+            only_if new_resource.exists_command, environment: new_resource.environment
           end
         end
       end

--- a/libraries/kafka_topic.rb
+++ b/libraries/kafka_topic.rb
@@ -39,7 +39,7 @@ module KafkaClusterCookbook
       # Builds shell command to check existence of Kafka topics.
       # @return [String]
       def exists_command
-        ['kafka-topics.sh --list', '--zookeeper', zookeeper, '| grep -i -w', topic_name].join(' ')
+        ['kafka-topics.sh --list', '--zookeeper', zookeeper, '| grep -w', topic_name].join(' ')
       end
 
       # The environment for shell command execution.

--- a/libraries/kafka_topic.rb
+++ b/libraries/kafka_topic.rb
@@ -55,7 +55,7 @@ module KafkaClusterCookbook
           execute new_resource.command('create') do
             guard_interpreter :default
             environment new_resource.environment
-            not_if new_resource.exists_command
+            not_if new_resource.exists_command, :environment => new_resource.environment
           end
         end
       end
@@ -65,7 +65,7 @@ module KafkaClusterCookbook
           execute new_resource.command('alter') do
             guard_interpreter :default
             environment new_resource.environment
-            only_if new_resource.exists_command
+            only_if new_resource.exists_command, :environment => new_resource.environment
           end
         end
       end
@@ -75,7 +75,7 @@ module KafkaClusterCookbook
           execute new_resource.command('delete') do
             guard_interpreter :default
             environment new_resource.environment
-            only_if new_resource.exists_command
+            only_if new_resource.exists_command, :environment => new_resource.environment
           end
         end
       end

--- a/libraries/kafka_topic.rb
+++ b/libraries/kafka_topic.rb
@@ -39,7 +39,7 @@ module KafkaClusterCookbook
       # Builds shell command to check existence of Kafka topics.
       # @return [String]
       def exists_command
-        ['kafka-topics.sh --list', '--zookeeper', zookeeper, '| grep -i', topic_name].join(' ')
+        ['kafka-topics.sh --list', '--zookeeper', zookeeper, '| grep -i -w', topic_name].join(' ')
       end
 
       # The environment for shell command execution.

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache 2.0'
 description 'Application cookbook which installs and configures Apache Kafka.'
 long_description 'Application cookbook which installs and configures Apache Kafka.'
-version '1.3.0'
+version '1.3.1'
 
 supports 'ubuntu', '>= 12.04'
 supports 'centos', '>= 6.6'

--- a/test/spec/libraries/kafka_topic_spec.rb
+++ b/test/spec/libraries/kafka_topic_spec.rb
@@ -5,7 +5,7 @@ describe KafkaClusterCookbook::Resource::KafkaTopic do
   step_into(:kafka_topic)
   context '#action_create' do
     before do
-      stub_command('kafka-topics.sh --list --zookeeper localhost:2181/kafka | grep -i test').and_return(false)
+      stub_command('kafka-topics.sh --list --zookeeper localhost:2181/kafka | grep -i -w test').and_return(false)
     end
     recipe do
       kafka_topic 'test' do
@@ -18,7 +18,7 @@ describe KafkaClusterCookbook::Resource::KafkaTopic do
 
   context '#action_delete' do
     before do
-      stub_command('kafka-topics.sh --list --zookeeper localhost:2181/kafka | grep -i test').and_return(true)
+      stub_command('kafka-topics.sh --list --zookeeper localhost:2181/kafka | grep -i -w test').and_return(true)
     end
     recipe do
       kafka_topic 'test' do
@@ -32,7 +32,7 @@ describe KafkaClusterCookbook::Resource::KafkaTopic do
 
   context '#action_update' do
     before do
-      stub_command('kafka-topics.sh --list --zookeeper localhost:2181/kafka | grep -i test').and_return(true)
+      stub_command('kafka-topics.sh --list --zookeeper localhost:2181/kafka | grep -i -w test').and_return(true)
     end
     recipe do
       kafka_topic 'test' do

--- a/test/spec/libraries/kafka_topic_spec.rb
+++ b/test/spec/libraries/kafka_topic_spec.rb
@@ -5,7 +5,7 @@ describe KafkaClusterCookbook::Resource::KafkaTopic do
   step_into(:kafka_topic)
   context '#action_create' do
     before do
-      stub_command('kafka-topics.sh --list --zookeeper localhost:2181/kafka | grep -i -w test').and_return(false)
+      stub_command('kafka-topics.sh --list --zookeeper localhost:2181/kafka | grep -w test').and_return(false)
     end
     recipe do
       kafka_topic 'test' do
@@ -18,7 +18,7 @@ describe KafkaClusterCookbook::Resource::KafkaTopic do
 
   context '#action_delete' do
     before do
-      stub_command('kafka-topics.sh --list --zookeeper localhost:2181/kafka | grep -i -w test').and_return(true)
+      stub_command('kafka-topics.sh --list --zookeeper localhost:2181/kafka | grep -w test').and_return(true)
     end
     recipe do
       kafka_topic 'test' do
@@ -32,7 +32,7 @@ describe KafkaClusterCookbook::Resource::KafkaTopic do
 
   context '#action_update' do
     before do
-      stub_command('kafka-topics.sh --list --zookeeper localhost:2181/kafka | grep -i -w test').and_return(true)
+      stub_command('kafka-topics.sh --list --zookeeper localhost:2181/kafka | grep -w test').and_return(true)
     end
     recipe do
       kafka_topic 'test' do


### PR DESCRIPTION
On every chef run, kafka topics were created even though the topics already existed. This was not an issue when we were using Kafka version 0.8.2.X but when we upgraded to 0.9.0.0, kafka-topics.sh behavior got changed, it started giving bad exit code which causes chef run to fail.

This fixes following:
* make grep more restrictive (ie to use -w ) so topic exists command will do exact match for the topic name
* pass environment to not_if guard so that kafka_topics.sh will be found in the PATH