### PR TITLE
Service should restart itself on package updates

### DIFF
--- a/libraries/kafka_service.rb
+++ b/libraries/kafka_service.rb
@@ -90,6 +90,7 @@ module KafkaClusterCookbook
           package new_resource.package_name do
             version new_resource.version unless new_resource.version.nil?
             only_if { new_resource.install_method == 'package' }
+            notifies :restart, new_resource, :delayed
           end
 
           libartifact_file "kafka-#{new_resource.version}" do
@@ -99,6 +100,7 @@ module KafkaClusterCookbook
             remote_url new_resource.binary_url % { version: new_resource.version }
             remote_checksum new_resource.binary_checksum
             only_if { new_resource.install_method == 'binary' }
+            notifies :restart, new_resource, :delayed
           end
 
           new_resource.data_dir.split(',').each do |datadir|

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache 2.0'
 description 'Application cookbook which installs and configures Apache Kafka.'
 long_description 'Application cookbook which installs and configures Apache Kafka.'
-version '1.3.1'
+version '1.3.2'
 
 supports 'ubuntu', '>= 12.04'
 supports 'centos', '>= 6.6'


### PR DESCRIPTION
The package and libartifact_file should cause the service resource to restart, if they're updated. Adding this small change, similar to how its done in the [redis cookbook](https://github.com/bloomberg/redis-cookbook/blob/master/libraries/redis_instance.rb#L130).