### PR TITLE
Undoing new_resource.notifies :restart

### DIFF
--- a/libraries/kafka_service.rb
+++ b/libraries/kafka_service.rb
@@ -86,7 +86,6 @@ module KafkaClusterCookbook
       include PoiseService::ServiceMixin
 
       def action_enable
-        new_resource.notifies(:restart, new_resource, :delayed)
         notifying_block do
           package new_resource.package_name do
             version new_resource.version unless new_resource.version.nil?

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache 2.0'
 description 'Application cookbook which installs and configures Apache Kafka.'
 long_description 'Application cookbook which installs and configures Apache Kafka.'
-version '1.3.2'
+version '1.3.3'
 
 supports 'ubuntu', '>= 12.04'
 supports 'centos', '>= 6.6'


### PR DESCRIPTION
We're seeing that, regardless of the resources being changed, this change is causing kafka to bounce every chef run. 

I'd like to undo this so we can shut up our production machines