### PR TITLE
topic exists to check complete match

### DIFF
--- a/libraries/kafka_topic.rb
+++ b/libraries/kafka_topic.rb
@@ -39,7 +39,7 @@ module KafkaClusterCookbook
       # Builds shell command to check existence of Kafka topics.
       # @return [String]
       def exists_command
-        ['kafka-topics.sh --list', '--zookeeper', zookeeper, '| grep -w', topic_name].join(' ')
+        ['kafka-topics.sh --list', '--zookeeper', zookeeper, '| grep ^', topic_name, '$'].join(' ')
       end
 
       # The environment for shell command execution.

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ issues_url 'https://github.com/bloomberg/kafka-cookbook/issues'
 source_url 'https://github.com/bloomberg/kafka-cookbook'
 description 'Application cookbook which installs and configures Apache Kafka.'
 long_description 'Application cookbook which installs and configures Apache Kafka.'
-version '1.3.5'
+version '1.3.6'
 
 supports 'ubuntu', '>= 12.04'
 supports 'centos', '>= 6.6'


### PR DESCRIPTION
kafka exists_command incorrectly returns true when a topic partially matches an existing topic.

Example: If "abc.def" topic already exists, then exists_command returns true for "def" topic as well, even though "def" topic does not exist.

Fix here is to do a complete match, ie from begin to end of line.