### PR TITLE
fix topic exist grep pattern

### DIFF
--- a/libraries/kafka_topic.rb
+++ b/libraries/kafka_topic.rb
@@ -39,7 +39,7 @@ module KafkaClusterCookbook
       # Builds shell command to check existence of Kafka topics.
       # @return [String]
       def exists_command
-        ['kafka-topics.sh --list', '--zookeeper', zookeeper, '| grep ^', topic_name, '$'].join(' ')
+        ['kafka-topics.sh --list', '--zookeeper', zookeeper, '| grep', topic_name.prepend('^').concat('$')].join(' ')
       end
 
       # The environment for shell command execution.

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ issues_url 'https://github.com/bloomberg/kafka-cookbook/issues'
 source_url 'https://github.com/bloomberg/kafka-cookbook'
 description 'Application cookbook which installs and configures Apache Kafka.'
 long_description 'Application cookbook which installs and configures Apache Kafka.'
-version '1.3.6'
+version '1.3.7'
 
 supports 'ubuntu', '>= 12.04'
 supports 'centos', '>= 6.6'


### PR DESCRIPTION
topic exist grep pattern that was added in #20 adds a space before and after the topic name and fails to find an existing topic.