### PR TITLE
Fix sysctl cookbook usage.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -10,8 +10,9 @@ node.default['java']['jdk_version'] = '8'
 node.default['java']['accept_license_agreement'] = true
 include_recipe 'java::default'
 
-node.default['sysctl']['params']['vm']['swappiness'] = 0
-include_recipe 'sysctl::apply'
+sysctl_param 'vm.swappiness' do
+  value 0
+end
 
 poise_service_user node['kafka-cluster']['service_user'] do
   group node['kafka-cluster']['service_group']


### PR DESCRIPTION
* Latest sysctl cookbook made apply recipe obsolete.
* Using the sysctl_param resource instead.
* See: https://supermarket.chef.io/cookbooks/sysctl
