### PR TITLE
Support custom configs

### DIFF
--- a/libraries/kafka_topic.rb
+++ b/libraries/kafka_topic.rb
@@ -20,6 +20,7 @@ module KafkaClusterCookbook
       attribute(:zookeeper, kind_of: [Array, String], required: true)
       attribute(:replication_factor, kind_of: Integer, default: 1)
       attribute(:partitions, kind_of: Integer, default: 1)
+      attribute(:configs, kind_of: [Array, String])
       attribute(:environment, kind_of: Hash, default: lazy { default_environment })
 
       # Builds shell command for managing Kafka topics.
@@ -30,6 +31,11 @@ module KafkaClusterCookbook
           c << ['--topic', topic_name]
           c << ['--zookeeper', [zookeeper].compact.join(',')]
           c << ['--partitions', partitions] if partitions
+          if type.to_s != 'delete'
+            configs.each do |config|
+              c << ['--config', config]
+            end if configs
+          end
           if type.to_s == 'create'
             c << ['--replication-factor', replication_factor] if replication_factor
           end

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ issues_url 'https://github.com/bloomberg/kafka-cookbook/issues'
 source_url 'https://github.com/bloomberg/kafka-cookbook'
 description 'Application cookbook which installs and configures Apache Kafka.'
 long_description 'Application cookbook which installs and configures Apache Kafka.'
-version '1.4.0'
+version '1.4.1'
 chef_version '>= 12.9'
 
 supports 'ubuntu', '>= 14.04'


### PR DESCRIPTION
Sample command:
`./kafka-topics.sh --create --topic test_create_topic --zookeeper localhost:2181 --partitions 10 --replication-factor 3 --config "compression.type=producer" --config "retention.ms=604800000"`

This lets someone create a topic using the format 
```
            {
              "topic": "test_create_topic",
              "partitions": 10,
              "replication_factor": 3,
              "configs": [
                "retention.ms=604800000",
                "compression.type=producer"
              ]
            },
```

Doing a delete with configs will cause failures, but alterations are allowed